### PR TITLE
Fix issue with spectrogram x-axis display

### DIFF
--- a/accusleepy/gui/manual_scoring.py
+++ b/accusleepy/gui/manual_scoring.py
@@ -583,10 +583,13 @@ class ManualScoringWindow(QtWidgets.QDialog):
 
     def adjust_upper_figure_x_limits(self) -> None:
         """Update the x-axis limits of the upper figure subplots"""
-        for i in range(4):
+        for i in [0, 1, 3]:
             self.ui.upperfigure.canvas.axes[i].set_xlim(
                 (self.upper_left_epoch - 0.5, self.upper_right_epoch + 0.5)
             )
+        self.ui.upperfigure.canvas.axes[2].set_xlim(
+            (self.upper_left_epoch, self.upper_right_epoch + 1)
+        )
         self.ui.upperfigure.canvas.draw()
 
     def zoom_x(self, direction: str) -> None:
@@ -778,7 +781,9 @@ class ManualScoringWindow(QtWidgets.QDialog):
         )
         self.ui.lowerfigure.canvas.axes[1].set_xticklabels(
             [
-                "{:02d}:{:02d}:{:05.2f}".format(int(x // 3600), int(x // 60), (x % 60))
+                "{:02d}:{:02d}:{:05.2f}".format(
+                    int(x // 3600), int(x // 60) % 60, (x % 60)
+                )
                 for x in x_ticks * self.epoch_length
             ]
         )

--- a/accusleepy/gui/mplwidget.py
+++ b/accusleepy/gui/mplwidget.py
@@ -96,9 +96,10 @@ class MplWidget(QWidget):
         axes.append(self.canvas.figure.add_subplot(gs1[2]))
         axes.append(self.canvas.figure.add_subplot(gs2[3]))
 
-        # the subplots might have different axes limits one day
-        for i in range(4):
+        # subplots have different axes limits
+        for i in [0, 1, 3]:
             axes[i].set_xlim((-0.5, n_epochs + 0.5))
+        axes[2].set_xlim(0, n_epochs)
 
         # brain state subplot
         axes[0].set_ylim(
@@ -161,6 +162,12 @@ class MplWidget(QWidget):
             aspect="auto",
             origin="lower",
             interpolation="None",
+            extent=(
+                0,
+                n_epochs,
+                -0.5,
+                len(f) + 0.5,
+            ),
         )
 
         # EMG subplot
@@ -304,8 +311,10 @@ class MplWidget(QWidget):
         self.canvas.axes = axes
 
     def time_formatter(self, x, pos):
-        x = (x + 0.5) * self.epoch_length
-        return "{:02d}:{:02d}:{:05.2f}".format(int(x // 3600), int(x // 60), (x % 60))
+        x = x * self.epoch_length
+        return "{:02d}:{:02d}:{:05.2f}".format(
+            int(x // 3600), int(x // 60) % 60, (x % 60)
+        )
 
 
 def resample_x_ticks(x_ticks: np.array) -> np.array:


### PR DESCRIPTION
Makes the spectrogram axis limits line up with epochs edges, not centers