### PR TITLE
Always load model to CPU

### DIFF
--- a/accusleepy/fileio.py
+++ b/accusleepy/fileio.py
@@ -82,7 +82,9 @@ def load_model(filename: str) -> tuple[SSANN, int | float, int, str, dict]:
         (default or real-time), set of brain state options
         used when training the model
     """
-    state_dict = torch.load(filename, weights_only=True)
+    state_dict = torch.load(
+        filename, weights_only=True, map_location=torch.device("cpu")
+    )
     epoch_length = state_dict.pop("epoch_length")
     epochs_per_img = state_dict.pop("epochs_per_img")
     model_type = state_dict.pop("model_type")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "accusleepy"
-version = "0.1.2"
+version = "0.1.3"
 description = "Python implementation of AccuSleep"
 authors = [
     {name = "Zeke Barger",email = "zekebarger@gmail.com"}


### PR DESCRIPTION
I guess if a model was trained with a CUDA device, it expects to be loaded onto one. This PR loads models with the CPU regardless, since the `score_recording` function will move it to an accelerator if one is available.