### PR TITLE
Bugfix for loading config

### DIFF
--- a/accusleepy/gui/manual_scoring.py
+++ b/accusleepy/gui/manual_scoring.py
@@ -111,7 +111,7 @@ class ManualScoringWindow(QtWidgets.QDialog):
         self.setWindowTitle("AccuSleePy manual scoring window")
 
         # load set of valid brain states
-        self.brain_state_set = load_config()
+        self.brain_state_set, _ = load_config()
 
         # initial setting for number of epochs to show in the lower plot
         self.epochs_to_show = 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "accusleepy"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python implementation of AccuSleep"
 authors = [
     {name = "Zeke Barger",email = "zekebarger@gmail.com"}


### PR DESCRIPTION
Ignore default epoch length when the manual scoring window loads the config