### PR TITLE
Less confusing display of training location

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "accusleepy"
-version = "0.2.2"
+version = "0.2.3"
 description = "Python implementation of AccuSleep"
 authors = [
     {name = "Zeke Barger",email = "zekebarger@gmail.com"}


### PR DESCRIPTION
In the"training image directory" display box, just show the parent folder of the temporary training image folder rather than the full path.